### PR TITLE
r: move error handling logic a bit (but not too far) outside of requset handlers

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	errCorsFail  = Forbidden()
+	errCorsFail  = Forbidden("you are not allowed in here")
 	allowMethods = []string{"HEAD", "GET", "PUT", "DELETE"}
 	allowHeaders = []string{
 		"Authorization",

--- a/endpoint.go
+++ b/endpoint.go
@@ -61,13 +61,13 @@ func (m *MuxWithError) HandleFunc(pattern string, handler func(http.ResponseWrit
 
 func RMSRouter() http.Handler {
 	folderMux := &MuxWithError{}
-	folderMux.HandleFunc("GET /", getFolder) // @nocheckin: GET also accepts HEAD?
+	folderMux.HandleFunc("GET /", getFolder)
 	folderMux.Handle("/", HandlerWithError(func(http.ResponseWriter, *http.Request) error {
 		return BadRequest("method not allowed on folders")
 	}))
 
 	documentMux := &MuxWithError{}
-	documentMux.HandleFunc("GET /", getDocument) // @nocheckin: GET also accepts HEAD?
+	documentMux.HandleFunc("GET /", getDocument)
 	documentMux.HandleFunc("PUT /", putDocument)
 	documentMux.HandleFunc("DELETE /", deleteDocument)
 	documentMux.Handle("/", HandlerWithError(func(http.ResponseWriter, *http.Request) error {
@@ -83,7 +83,7 @@ func RMSRouter() http.Handler {
 		} else {
 			documentMux.ServeHTTP(w, r)
 		}
-		return nil // @nocheckin: ?
+		return nil
 	})
 
 	return mux

--- a/endpoint.go
+++ b/endpoint.go
@@ -33,13 +33,11 @@ type (
 )
 
 func MiddlewareStack(middlewares ...Middleware) Middleware {
-	// @nocheckin: test that this really works the way I think it does
 	return func(next http.Handler) http.Handler {
 		for i := len(middlewares)-1; i >= 0; i-- {
 			m := middlewares[i]
 			next = m(next)
 		}
-
 		return next
 	}
 }

--- a/endpoint.go
+++ b/endpoint.go
@@ -62,21 +62,17 @@ func (m *MuxWithError) HandleFunc(pattern string, handler func(http.ResponseWrit
 func RMSRouter() http.Handler {
 	folderMux := &MuxWithError{}
 	folderMux.HandleFunc("GET /", getFolder) // @nocheckin: GET also accepts HEAD?
-	folderMux.Handle("/", ErrMethodNotAllowed{
-		HttpError: HttpError{
-			Status: http.StatusMethodNotAllowed,
-		},
-	}) // @todo: return detailed error description
+	folderMux.Handle("/", HandlerWithError(func(http.ResponseWriter, *http.Request) error {
+		return BadRequest("method not allowed on folders")
+	}))
 
 	documentMux := &MuxWithError{}
 	documentMux.HandleFunc("GET /", getDocument) // @nocheckin: GET also accepts HEAD?
 	documentMux.HandleFunc("PUT /", putDocument)
 	documentMux.HandleFunc("DELETE /", deleteDocument)
-	documentMux.Handle("/", ErrMethodNotAllowed{
-		HttpError: HttpError{
-			Status: http.StatusMethodNotAllowed,
-		},
-	}) // @todo: return detailed error description
+	documentMux.Handle("/", HandlerWithError(func(http.ResponseWriter, *http.Request) error {
+		return BadRequest("method not allowed on documents")
+	}))
 
 	mux := &MuxWithError{}
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) error {

--- a/endpoint.go
+++ b/endpoint.go
@@ -17,7 +17,6 @@ import (
 // > A provider MAY offer version rollback functionality to its users,
 // > but this specification does not define the interface for that.
 
-
 type (
 	Middleware func(next http.Handler) http.Handler
 
@@ -34,7 +33,7 @@ type (
 
 func MiddlewareStack(middlewares ...Middleware) Middleware {
 	return func(next http.Handler) http.Handler {
-		for i := len(middlewares)-1; i >= 0; i-- {
+		for i := len(middlewares) - 1; i >= 0; i-- {
 			m := middlewares[i]
 			next = m(next)
 		}

--- a/errors.go
+++ b/errors.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 )
 
-// @nocheckin: some of these might be better of as sentinel error values, instead of constructing them anew each time
-
 type (
 	// @todo: to be extended as a RFC 9457 compliant error
 	//   (?maybe as its own library?)

--- a/errors.go
+++ b/errors.go
@@ -83,7 +83,6 @@ func (e HttpError) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h := w.Header()
 	h.Set("Content-Type", "application/problem+json") // respond with problem+json even if the client didn't request it (rfc9457#section-3-11)
 
-	// @nocheckin
 	//text := http.StatusText(e.Status) // @todo: replace with RFC 9457 formatted error response
 	//http.Error(w, text, e.Status)
 
@@ -159,7 +158,7 @@ func (e ErrMaybeNotFound) Unwrap() error {
 }
 
 func (e ErrMaybeNotFound) IsNotFound() bool {
-	return errors.Is(e.Cause, ErrNotExist) // @nocheckin: other possible not founds?
+	return errors.Is(e.Cause, ErrNotExist) // @todo: other possible not founds?
 }
 
 func (e ErrMaybeNotFound) RespondError(w http.ResponseWriter, r *http.Request) bool {

--- a/errors.go
+++ b/errors.go
@@ -1,20 +1,20 @@
 package rmsgo
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"encoding/json"
 )
 
 type (
 	// @todo: to be extended as a RFC 9457 compliant error
 	//   (?maybe as its own library?)
 	HttpError struct {
-		Type string `json:"type"`
-		Status int `json:"status"`
-		Title string `json:"title"`
-		Detail string `json:"detail"`
+		Type     string `json:"type"`
+		Status   int    `json:"status"`
+		Title    string `json:"title"`
+		Detail   string `json:"detail"`
 		Instance string `json:"instance"`
 	}
 
@@ -106,7 +106,7 @@ func BadRequest(msg string) error {
 	return ErrBadRequest{
 		HttpError: HttpError{
 			Status: s,
-			Title: http.StatusText(s),
+			Title:  http.StatusText(s),
 			Detail: msg,
 		},
 	}
@@ -117,7 +117,7 @@ func MethodNotAllowed(msg string) error {
 	return ErrMethodNotAllowed{
 		HttpError: HttpError{
 			Status: s,
-			Title: http.StatusText(s),
+			Title:  http.StatusText(s),
 		},
 	}
 }
@@ -127,7 +127,7 @@ func Forbidden(msg string) error {
 	return ErrForbidden{
 		HttpError: HttpError{
 			Status: s,
-			Title: http.StatusText(s),
+			Title:  http.StatusText(s),
 		},
 	}
 }
@@ -137,7 +137,7 @@ func NotFound(msg string) error {
 	return ErrNotFound{
 		HttpError: HttpError{
 			Status: s,
-			Title: http.StatusText(s),
+			Title:  http.StatusText(s),
 		},
 	}
 }
@@ -147,7 +147,7 @@ func MaybeNotFound(err error) error {
 	return ErrMaybeNotFound{
 		HttpError: HttpError{
 			Status: s,
-			Title: http.StatusText(s),
+			Title:  http.StatusText(s),
 		},
 		Cause: err,
 	}
@@ -172,7 +172,7 @@ func NotAFolder(path string) error {
 	return ErrNotAFolder{
 		HttpError: HttpError{
 			Status: http.StatusBadRequest,
-			Title: "requested resource is not a folder",
+			Title:  "requested resource is not a folder",
 			Detail: "a request was made to retrieve a folder, but a document with the same path was found",
 			// @todo: fmt.Sprintf("%s", path),
 		},
@@ -183,7 +183,7 @@ func NotADocument(path string) error {
 	return ErrNotADocument{
 		HttpError: HttpError{
 			Status: http.StatusBadRequest,
-			Title: "requested resource is not a document",
+			Title:  "requested resource is not a document",
 			Detail: "a request was made to retrieve a document, but a folder with the same path was found",
 			// @todo: fmt.Sprintf("%s", path),
 		},
@@ -192,9 +192,9 @@ func NotADocument(path string) error {
 
 func InvalidIfNonMatch(cond string) error {
 	return ErrInvalidIfNonMatch{
-		HttpError: HttpError {
+		HttpError: HttpError{
 			Status: http.StatusBadRequest,
-			Title: "invalid etag",
+			Title:  "invalid etag",
 			Detail: "the etag contained in the If-None-Match header could not be parsed",
 			// @todo: fmt.Sprintf("%s", cond),
 		},
@@ -203,9 +203,9 @@ func InvalidIfNonMatch(cond string) error {
 
 func InvalidIfMatch(cond string) error {
 	return ErrInvalidIfMatch{
-		HttpError: HttpError {
+		HttpError: HttpError{
 			Status: http.StatusBadRequest,
-			Title: "invalid etag",
+			Title:  "invalid etag",
 			Detail: "the etag contained in the If-Match header could not be parsed",
 			// @todo: fmt.Sprintf("%s", cond),
 		},
@@ -230,7 +230,7 @@ func Conflict(path string) error {
 	return ErrConflict{
 		HttpError: HttpError{
 			Status: http.StatusConflict,
-			Title: "conflicting path names",
+			Title:  "conflicting path names",
 			Detail: "the document conflicts with an already existing folder of the same name",
 			// @todo: fmt.Sprintf("%s", cond),
 		},
@@ -241,7 +241,7 @@ func MaybeAncestorConflict(err error, path string) error {
 	return ErrMaybeAncestorConflict{
 		HttpError: HttpError{
 			Status: http.StatusConflict,
-			Title: "conflicting path names while creating ancestors",
+			Title:  "conflicting path names while creating ancestors",
 			Detail: "the name of an ancestor collides with the name of an existing document",
 			// @todo: fmt.Sprintf("%s", cond),
 			//   err.(ConflictError).ConflictPath
@@ -270,7 +270,7 @@ func DocExists(path string) error {
 	return ErrDocExists{
 		HttpError: HttpError{
 			Status: http.StatusPreconditionFailed,
-			Title: "document already exists",
+			Title:  "document already exists",
 			Detail: "the request was rejected because the requested document already exists, but If-None-Match with a value of * was specified",
 			// @todo: fmt.Sprintf("%s", cond),
 		},
@@ -281,7 +281,7 @@ func VersionMismatch(expected, actual ETag) error {
 	return ErrVersionMismatch{
 		HttpError: HttpError{
 			Status: http.StatusPreconditionFailed,
-			Title: "version mismatch",
+			Title:  "version mismatch",
 			Detail: "the version provided in the If-Match header does not match the document's current version",
 			// @todo: expected, actual
 		},

--- a/errors.go
+++ b/errors.go
@@ -6,71 +6,246 @@ import (
 	"net/http"
 )
 
-// Sentinel error values
-var (
-	ErrServerError         = errors.New("internal server error")
-	ErrNotImplemented      = errors.New("not implemented")
-	ErrNotModified         = errors.New("not modified")
-	ErrUnauthorized        = errors.New("missing or invalid bearer token")
-	ErrForbidden           = errors.New("insufficient scope")
-	ErrNotFound            = errors.New("resource not found")
-	ErrConflict            = errors.New("conflicting document/folder names")
-	ErrPreconditionFailed  = errors.New("precondition failed")
-	ErrTooLarge            = errors.New("request entity too large")
-	ErrUriTooLong          = errors.New("request uri too long")
-	ErrRangeNotSatisfiable = errors.New("request range not satisfiable")
-	ErrTooManyRequests     = errors.New("too many requests")
-	ErrMethodNotAllowed    = errors.New("method not allowed")
-	ErrInsufficientStorage = errors.New("insufficient storage")
-	ErrBadRequest          = errors.New("bad request")
+// @nocheckin: some of these might be better of as sentinel error values, instead of constructing them anew each time
+
+type (
+	// @todo: to be extended as a RFC 9457 compliant error
+	//   (?maybe as its own library?)
+	HttpError struct {
+		Type string
+		Status int
+		Title string
+		Detail string
+		Instance string
+	}
+
+	ErrMethodNotAllowed struct {
+		HttpError
+	}
+
+	ErrForbidden struct {
+		HttpError
+	}
+
+	ErrNotFound struct {
+		HttpError
+	}
+
+	ErrMaybeNotFound struct {
+		HttpError
+		Cause error
+	}
+
+	ErrNotAFolder struct {
+		HttpError
+	}
+
+	ErrNotADocument struct {
+		HttpError
+	}
+
+	ErrInvalidIfNonMatch struct {
+		HttpError
+	}
+
+	ErrInvalidIfMatch struct {
+		HttpError
+	}
+
+	ErrNotModified struct {
+		HttpError
+	}
+
+	ErrConflict struct {
+		HttpError
+	}
+
+	ErrMaybeAncestorConflict struct {
+		HttpError
+		Cause error
+	}
+
+	ErrDocExists struct {
+		HttpError
+	}
+
+	ErrVersionMismatch struct {
+		HttpError
+	}
 )
 
-// StatusCodes maps errors to their respective HTTP status codes
-var StatusCodes = map[error]int{
-	ErrServerError:         500,
-	ErrNotImplemented:      501,
-	ErrNotModified:         304,
-	ErrUnauthorized:        401,
-	ErrForbidden:           403,
-	ErrNotFound:            404,
-	ErrConflict:            409,
-	ErrPreconditionFailed:  412,
-	ErrTooLarge:            413,
-	ErrUriTooLong:          414,
-	ErrRangeNotSatisfiable: 416,
-	ErrTooManyRequests:     429,
-	ErrMethodNotAllowed:    405,
-	ErrInsufficientStorage: 507,
-	ErrBadRequest:          400,
-}
-
-// HttpError contains detailed error information, intended to be shown to users.
-// No sensitive data should be contained by any of its fields (with Cause being
-// the only exception).
-type HttpError struct {
-	// Msg is a human readable error message.
-	Msg string
-	// Desc provides additional information to the error.
-	Desc string
-	// A URL where further details or help for the solution can be found.
-	URL string
-	// Additonal Data related to the error.
-	Data LDjson
-	// Underlying error that caused the exception.
-	// Cause is used to look up a response status in StatusCodes.
-	// If not contained in StatusCodes, ErrServerError is used instead, and the
-	// Cause is passed to the library user for further handling.
-	Cause error
-}
-
 func (e HttpError) Error() string {
-	status, ok := StatusCodes[e.Cause]
-	if !ok {
-		status = StatusCodes[ErrServerError]
-	}
-	return fmt.Sprintf("%d %s: %s", status, http.StatusText(status), e.Msg)
+	return fmt.Sprintf("%#v", e)
 }
 
-func (e HttpError) Unwrap() error {
+func (e HttpError) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	text := http.StatusText(e.Status) // @todo: replace with RFC 9457 formatted error response
+	http.Error(w, text, e.Status)
+}
+
+func (e HttpError) RespondError(w http.ResponseWriter, r *http.Request) bool {
+	http.Error(w, http.StatusText(e.Status), e.Status)
+	return true
+}
+
+func MethodNotAllowed() error {
+	return ErrMethodNotAllowed{
+		HttpError: HttpError{
+			Status: http.StatusMethodNotAllowed,
+		},
+	}
+}
+
+func Forbidden() error {
+	return ErrForbidden{
+		HttpError: HttpError{
+			Status: http.StatusForbidden,
+		},
+	}
+}
+
+func NotFound() error {
+	return ErrNotFound{
+		HttpError: HttpError{
+			Status: http.StatusNotFound,
+		},
+	}
+}
+
+func MaybeNotFound(err error) error {
+	return ErrMaybeNotFound{
+		HttpError: HttpError{
+			Status: http.StatusNotFound,
+		},
+		Cause: err,
+	}
+}
+
+func (e ErrMaybeNotFound) Unwrap() error {
 	return e.Cause
+}
+
+func (e ErrMaybeNotFound) IsNotFound() bool {
+	return errors.Is(e.Cause, ErrNotExist) // @nocheckin: other possible not founds?
+}
+
+func (e ErrMaybeNotFound) RespondError(w http.ResponseWriter, r *http.Request) bool {
+	if e.IsNotFound() {
+		return e.HttpError.RespondError(w, r)
+	}
+	return false
+}
+
+func NotAFolder(path string) error {
+	return ErrNotAFolder{
+		HttpError: HttpError{
+			Status: http.StatusBadRequest,
+			Title: "requested resource is not a folder",
+			Detail: "a request was made to retrieve a folder, but a document with the same path was found",
+			// @todo: fmt.Sprintf("%s", path),
+		},
+	}
+}
+
+func NotADocument(path string) error {
+	return ErrNotADocument{
+		HttpError: HttpError{
+			Status: http.StatusBadRequest,
+			Title: "requested resource is not a document",
+			Detail: "a request was made to retrieve a document, but a folder with the same path was found",
+			// @todo: fmt.Sprintf("%s", path),
+		},
+	}
+}
+
+func InvalidIfNonMatch(cond string) error {
+	return ErrInvalidIfNonMatch{
+		HttpError: HttpError {
+			Status: http.StatusBadRequest,
+			Title: "invalid etag",
+			Detail: "the etag contained in the If-None-Match header could not be parsed",
+			// @todo: fmt.Sprintf("%s", cond),
+		},
+	}
+}
+
+func InvalidIfMatch(cond string) error {
+	return ErrInvalidIfMatch{
+		HttpError: HttpError {
+			Status: http.StatusBadRequest,
+			Title: "invalid etag",
+			Detail: "the etag contained in the If-Match header could not be parsed",
+			// @todo: fmt.Sprintf("%s", cond),
+		},
+	}
+}
+
+func NotModified() error {
+	return ErrNotModified{
+		HttpError: HttpError{
+			Status: http.StatusNotModified,
+		},
+	}
+}
+
+func Conflict(path string) error {
+	return ErrConflict{
+		HttpError: HttpError{
+			Status: http.StatusConflict,
+			Title: "conflicting path names",
+			Detail: "the document conflicts with an already existing folder of the same name",
+			// @todo: fmt.Sprintf("%s", cond),
+		},
+	}
+}
+
+func MaybeAncestorConflict(err error, path string) error {
+	return ErrMaybeAncestorConflict{
+		HttpError: HttpError{
+			Status: http.StatusConflict,
+			Title: "conflicting path names while creating ancestors",
+			Detail: "the name of an ancestor collides with the name of an existing document",
+			// @todo: fmt.Sprintf("%s", cond),
+			//   err.(ConflictError).ConflictPath
+		},
+		Cause: err,
+	}
+}
+
+func (e ErrMaybeAncestorConflict) Unwrap() error {
+	return e.Cause
+}
+
+func (e ErrMaybeAncestorConflict) AsConflict(conflict *ConflictError) bool {
+	return errors.As(e.Cause, conflict)
+}
+
+func (e ErrMaybeAncestorConflict) RespondError(w http.ResponseWriter, r *http.Request) bool {
+	var errConflict ConflictError
+	if isConflict := e.AsConflict(&errConflict); isConflict {
+		return e.HttpError.RespondError(w, r)
+	}
+	return false
+}
+
+func DocExists(path string) error {
+	return ErrDocExists{
+		HttpError: HttpError{
+			Status: http.StatusPreconditionFailed,
+			Title: "document already exists",
+			Detail: "the request was rejected because the requested document already exists, but If-None-Match with a value of * was specified",
+			// @todo: fmt.Sprintf("%s", cond),
+		},
+	}
+}
+
+func VersionMismatch(expected, actual ETag) error {
+	return ErrVersionMismatch{
+		HttpError: HttpError{
+			Status: http.StatusPreconditionFailed,
+			Title: "version mismatch",
+			Detail: "the version provided in the If-Match header does not match the document's current version",
+			// @todo: expected, actual
+		},
+	}
 }

--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,10 @@ type (
 		Instance string `json:"instance"`
 	}
 
+	ErrBadRequest struct {
+		HttpError
+	}
+
 	ErrMethodNotAllowed struct {
 		HttpError
 	}
@@ -98,34 +102,53 @@ func (e HttpError) RespondError(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-func MethodNotAllowed() error {
+func BadRequest(msg string) error {
+	s := http.StatusBadRequest
+	return ErrBadRequest{
+		HttpError: HttpError{
+			Status: s,
+			Title: http.StatusText(s),
+			Detail: msg,
+		},
+	}
+}
+
+func MethodNotAllowed(msg string) error {
+	s := http.StatusMethodNotAllowed
 	return ErrMethodNotAllowed{
 		HttpError: HttpError{
-			Status: http.StatusMethodNotAllowed,
+			Status: s,
+			Title: http.StatusText(s),
 		},
 	}
 }
 
-func Forbidden() error {
+func Forbidden(msg string) error {
+	s := http.StatusForbidden
 	return ErrForbidden{
 		HttpError: HttpError{
-			Status: http.StatusForbidden,
+			Status: s,
+			Title: http.StatusText(s),
 		},
 	}
 }
 
-func NotFound() error {
+func NotFound(msg string) error {
+	s := http.StatusNotFound
 	return ErrNotFound{
 		HttpError: HttpError{
-			Status: http.StatusNotFound,
+			Status: s,
+			Title: http.StatusText(s),
 		},
 	}
 }
 
 func MaybeNotFound(err error) error {
+	s := http.StatusNotFound
 	return ErrMaybeNotFound{
 		HttpError: HttpError{
-			Status: http.StatusNotFound,
+			Status: s,
+			Title: http.StatusText(s),
 		},
 		Cause: err,
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cvanloo/rmsgo
 
-go 1.21.0
+go 1.22.5
 
 require (
 	github.com/google/uuid v1.3.0

--- a/mock/vars.go
+++ b/mock/vars.go
@@ -47,12 +47,14 @@ func Mock(fsOpts ...FSOption) {
 // UUIDFunc returns a mock function that creates predictable UUIDs, simply a
 // number starting at one, being increased for each new UUID.
 func UUIDFunc() func() (uuid.UUID, error) {
-	last := 48
+	last := uint32(48)
 	return func() (uuid.UUID, error) {
 		last++
 		bs := make([]byte, 16)
-		bs[0] = byte((last >> 0) & 0xFF)
-		bs[1] = byte((last >> 8) & 0xFF)
+		bs[0] = byte((last >>  0) & 0xFF)
+		bs[1] = byte((last >>  8) & 0xFF)
+		bs[2] = byte((last >> 16) & 0xFF)
+		bs[3] = byte((last >> 24) & 0xFF)
 		return uuid.FromBytes(bs)
 	}
 }

--- a/mock/vars.go
+++ b/mock/vars.go
@@ -51,7 +51,7 @@ func UUIDFunc() func() (uuid.UUID, error) {
 	last := 0
 	return func() (uuid.UUID, error) {
 		last++
-		lastX := fmt.Sprintf("%x", last)
+		lastX := fmt.Sprintf("%016x", last) // @nocheckin
 		return uuid.UUID([]byte(lastX)[:16]), nil
 	}
 }

--- a/mock/vars.go
+++ b/mock/vars.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-	"fmt"
 	"github.com/cvanloo/go-ffs"
 	"time"
 
@@ -48,11 +47,13 @@ func Mock(fsOpts ...FSOption) {
 // UUIDFunc returns a mock function that creates predictable UUIDs, simply a
 // number starting at one, being increased for each new UUID.
 func UUIDFunc() func() (uuid.UUID, error) {
-	last := 0
+	last := 48
 	return func() (uuid.UUID, error) {
 		last++
-		lastX := fmt.Sprintf("%016x", last) // @nocheckin
-		return uuid.UUID([]byte(lastX)[:16]), nil
+		bs := make([]byte, 16)
+		bs[0] = byte((last >> 0) & 0xFF)
+		bs[1] = byte((last >> 8) & 0xFF)
+		return uuid.FromBytes(bs)
 	}
 }
 

--- a/mock/vars.go
+++ b/mock/vars.go
@@ -51,8 +51,8 @@ func UUIDFunc() func() (uuid.UUID, error) {
 	return func() (uuid.UUID, error) {
 		last++
 		bs := make([]byte, 16)
-		bs[0] = byte((last >>  0) & 0xFF)
-		bs[1] = byte((last >>  8) & 0xFF)
+		bs[0] = byte((last >> 0) & 0xFF)
+		bs[1] = byte((last >> 8) & 0xFF)
 		bs[2] = byte((last >> 16) & 0xFF)
 		bs[3] = byte((last >> 24) & 0xFF)
 		return uuid.FromBytes(bs)

--- a/server.go
+++ b/server.go
@@ -41,6 +41,8 @@ type (
 		authenticate    AuthenticateFunc
 	}
 
+	// @todo: domain name (needed eg., for rfc9457 errors)
+
 	// ErrorHandlerFunc is passed any errors that the remoteStorage server
 	// doesn't know how to handle itself.
 	ErrorHandlerFunc func(err error)


### PR DESCRIPTION
This defines a `HandlerWithError` adapter to allow requests to return errors instead of having to handle error cases themselves.

Instead of having a specific `HttpError` type, this is now an interface with a single `RespondError` method. (The interface is called `ErrorResponder`, there is a new `HttpError` type that can be used to compose more specific types.)

There are custom HttpError implementations for specific error cases, so that the error handling logic can be moved out of the request handlers and into the respective implementations of `RespondError`.

In the future error responses should be RFC9457 compliant (see #3).

ref: #17 