### PR TITLE
r: use options pattern

### DIFF
--- a/cmd/rms_server/main.go
+++ b/cmd/rms_server/main.go
@@ -112,7 +112,7 @@ func main() {
 			log.Fatalf("remote storage: unhandled error: %v", err)
 		}),
 		rmsgo.WithMiddleware(logger),
-		rmsgo.WithCondition(!allOrigins, rmsgo.WithAllowedOrigins(origins.Origins)), // allow all is the default in opts
+		rmsgo.Optionally(!allOrigins, rmsgo.WithAllowedOrigins(origins.Origins)), // allow all is the default in opts
 		rmsgo.WithAuthentication(func(r *http.Request, bearer string) (rmsgo.User, bool) {
 			return rmsgo.UserReadWrite{}, true
 		}),

--- a/cmd/rms_server/main.go
+++ b/cmd/rms_server/main.go
@@ -107,7 +107,7 @@ func main() {
 		log.Fatalf("storage root does not exist: %v", err)
 	}
 
-	_, err = rmsgo.Configure(*rroot, *sroot,
+	err = rmsgo.Configure(*rroot, *sroot,
 		rmsgo.WithErrorHandler(func(err error) {
 			log.Fatalf("remote storage: unhandled error: %v", err)
 		}),

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -22,7 +22,7 @@ func mockServer(opts ...Option) (ts *httptest.Server, s *Server, root string) {
 	)
 	s = mustVal(Configure(rroot, sroot,
 		WithAllowAnyReadWrite(),
-		Options(opts).Combine(),
+		Options(opts...),
 	))
 	Reset()
 

--- a/server.go
+++ b/server.go
@@ -8,14 +8,12 @@
 // Storage root refers to the location on disk where the actual "Kitten.avif"
 // file is stored (for example "/var/storage").
 //
-// Use the Configure function and the methods on the returned Options struct
-// to setup the server.
+// Use the Configure function and the various Options to setup the server.
 //
-//	opts, err := rmsgo.Configure(RemoteRoot, StorageRoot)
+//	err := rmsgo.Configure(RemoteRoot, StorageRoot, WithXXX(...), ...)
 //	if err != nil {
 //		log.Fatal(err)
 //	}
-//	opts.UseXXX(...)
 package rmsgo
 
 import (
@@ -29,8 +27,11 @@ import (
 )
 
 type (
+	// Option configures the Server.
+	// You're not supposed to create an Option yourself, but instead use the WithXXX functions.
 	Option func(*Server)
 
+	// Server holds the server configuration.
 	Server struct {
 		rroot, sroot    string
 		allowAllOrigins bool
@@ -179,7 +180,8 @@ func WithAllowOrigin(f AllowOriginFunc) Option {
 	}
 }
 
-func WithCondition(cond bool, opt Option) Option {
+// Optionally use opt depending on cond.
+func Optionally(cond bool, opt Option) Option {
 	return func(s *Server) {
 		if cond {
 			opt(s)
@@ -187,6 +189,7 @@ func WithCondition(cond bool, opt Option) Option {
 	}
 }
 
+// Group multiple Options together into a single Option.
 func Options(opts ...Option) Option {
 	return func(s *Server) {
 		for _, opt := range opts {

--- a/server.go
+++ b/server.go
@@ -31,8 +31,6 @@ import (
 type (
 	Option func(*Server) error
 
-	Options []Option
-
 	Server struct {
 		rroot, sroot    string
 		allowAllOrigins bool
@@ -213,18 +211,14 @@ func WithCondition(cond bool, opt Option) Option {
 	}
 }
 
-func (opts Options) apply(s *Server) error {
-	for _, opt := range opts {
-		if err := opt(s); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (opts Options) Combine() Option {
+func Options(opts ...Option) Option {
 	return func(s *Server) error {
-		return opts.apply(s)
+		for _, opt := range opts {
+			if err := opt(s); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -68,7 +68,7 @@ var g *Server
 // documents are written to and read from.
 // It is recommended to properly configure authentication by using the
 // WithAuthentication option.
-func Configure(remoteRoot, storageRoot string, opts ...Option) (*Server, error) {
+func Configure(remoteRoot, storageRoot string, opts ...Option) error {
 	rroot := filepath.Clean(remoteRoot)
 	if rroot == "/" {
 		rroot = ""
@@ -77,10 +77,10 @@ func Configure(remoteRoot, storageRoot string, opts ...Option) (*Server, error) 
 	sroot := filepath.Clean(storageRoot)
 	fi, err := FS.Stat(sroot)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if !fi.IsDir() {
-		return nil, fmt.Errorf("storage root is not a directory: %s", sroot)
+		return fmt.Errorf("storage root is not a directory: %s", sroot)
 	}
 
 	s := &Server{
@@ -113,22 +113,7 @@ func Configure(remoteRoot, storageRoot string, opts ...Option) (*Server, error) 
 	}
 
 	g = s
-	return s, nil
-}
-
-// Rroot specifies the URL path at which remoteStorage is rooted.
-// E.g., if Rroot is "/storage" then a document "/Picture/Kittens.png" can
-// be accessed using the URL "https://example.com/storage/Picture/Kittens.png".
-// Rroot does not have a trailing slash.
-func (o *Server) Rroot() string {
-	return o.rroot
-}
-
-// Sroot is a path specifying the location on the server's file system where
-// all of remoteStorage's files are stored. Sroot does not have a trailing
-// slash.
-func (o *Server) Sroot() string {
-	return o.sroot
+	return nil
 }
 
 // WithErrorHandler configures the error handler to use.

--- a/server.go
+++ b/server.go
@@ -29,7 +29,7 @@ import (
 )
 
 type (
-	Option func(*Server) error
+	Option func(*Server)
 
 	Server struct {
 		rroot, sroot    string
@@ -109,9 +109,7 @@ func Configure(remoteRoot, storageRoot string, opts ...Option) (*Server, error) 
 	}
 
 	for _, opt := range opts {
-		if err := opt(s); err != nil {
-			return nil, err
-		}
+		opt(s)
 	}
 
 	g = s
@@ -135,9 +133,8 @@ func (o *Server) Sroot() string {
 
 // WithErrorHandler configures the error handler to use.
 func WithErrorHandler(h ErrorHandlerFunc) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		s.unhandled = h
-		return nil
 	}
 }
 
@@ -147,9 +144,8 @@ func WithErrorHandler(h ErrorHandlerFunc) Option {
 // using next.ServeHTTP(w, r).
 // If this is not done correctly, rmsgo won't be able to handle requests.
 func WithMiddleware(m Middleware) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		s.middleware = m
-		return nil
 	}
 }
 
@@ -160,9 +156,8 @@ func WithMiddleware(m Middleware) Option {
 // is configured, read-only (GET and HEAD) requests are allowed for the
 // unauthenticated user.
 func WithAllowAnyReadWrite() Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		s.defaultUser = UserReadWrite{}
-		return nil
 	}
 }
 
@@ -174,9 +169,8 @@ func WithAllowAnyReadWrite() Option {
 // In case of an authenticated user, access rights are determined based on the
 // user's Permission method.
 func WithAuthentication(a AuthenticateFunc) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		s.authenticate = a
-		return nil
 	}
 }
 
@@ -184,10 +178,9 @@ func WithAuthentication(a AuthenticateFunc) Option {
 // By default all origins are allowed.
 // This option is ignored if WithAllowOrigin is called.
 func WithAllowedOrigins(origins []string) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		s.allowAllOrigins = false
 		s.allowedOrigins = origins
-		return nil
 	}
 }
 
@@ -195,30 +188,25 @@ func WithAllowedOrigins(origins []string) Option {
 // whether an origin is allowed or not.
 // If this option is set up, the list of origins set by WithAllowOrigins is ignored.
 func WithAllowOrigin(f AllowOriginFunc) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		s.allowAllOrigins = false
 		s.allowOrigin = f
-		return nil
 	}
 }
 
 func WithCondition(cond bool, opt Option) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		if cond {
-			return opt(s)
+			opt(s)
 		}
-		return nil
 	}
 }
 
 func Options(opts ...Option) Option {
-	return func(s *Server) error {
+	return func(s *Server) {
 		for _, opt := range opts {
-			if err := opt(s); err != nil {
-				return err
-			}
+			opt(s)
 		}
-		return nil
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -76,9 +76,9 @@ func ExampleRegister_usingDefaultServeMux() {
 	}
 }
 
-// Configure returns a reference to an options object.
-// This can be used to customize the configuration, e.g., to configure CORS,
-// and to setup authentication, additional middleware, and more.
+// Configure accepts a variable number of Option arguments.
+// These can be used to overwrite the default configuration, e.g., to configure
+// CORS, setup authentication, additional middleware, and more.
 func ExampleOptions() {
 	const (
 		remoteRoot  = "/storage/"

--- a/server_test.go
+++ b/server_test.go
@@ -26,7 +26,7 @@ func ExampleRegister() {
 		log.Fatal(err)
 	}
 
-	_, err = rmsgo.Configure(remoteRoot, storageRoot)
+	err = rmsgo.Configure(remoteRoot, storageRoot)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func ExampleRegister_usingDefaultServeMux() {
 		log.Fatal(err)
 	}
 
-	_, err = rmsgo.Configure(remoteRoot, storageRoot)
+	err = rmsgo.Configure(remoteRoot, storageRoot)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func ExampleOptions() {
 		storageRoot = "/var/rms/storage/"
 	)
 
-	_, err := rmsgo.Configure(remoteRoot, storageRoot,
+	err := rmsgo.Configure(remoteRoot, storageRoot,
 
 		rmsgo.WithErrorHandler(func(err error) {
 			log.Panicf("remote storage: unhandled error: %v", err)

--- a/server_test.go
+++ b/server_test.go
@@ -85,41 +85,42 @@ func ExampleOptions() {
 		storageRoot = "/var/rms/storage/"
 	)
 
-	opts, err := rmsgo.Configure(remoteRoot, storageRoot)
+	_, err := rmsgo.Configure(remoteRoot, storageRoot,
+
+		rmsgo.WithErrorHandler(func(err error) {
+			log.Panicf("remote storage: unhandled error: %v", err)
+		}),
+
+		rmsgo.WithMiddleware(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				start := time.Now()
+				lrw := rmsgo.NewLoggingResponseWriter(w)
+
+				// [!] Pass request on to remote storage server
+				next.ServeHTTP(lrw, r)
+
+				duration := time.Since(start)
+
+				// maybe use an actual library for structured logging
+				log.Printf("%v", map[string]any{
+					"method":   r.Method,
+					"uri":      r.RequestURI,
+					"duration": duration,
+					"status":   lrw.Status,
+					"size":     lrw.Size,
+				})
+			})
+		}),
+
+		rmsgo.WithAuthentication(func(r *http.Request, bearer string) (rmsgo.User, bool) {
+			// [!] TODO: Your authentication logic here...
+			//       Return one of your own users.
+			return rmsgo.UserReadWrite{}, true
+		}),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	opts.UseErrorHandler(func(err error) {
-		log.Panicf("remote storage: unhandled error: %v", err)
-	})
-
-	opts.UseMiddleware(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			start := time.Now()
-			lrw := rmsgo.NewLoggingResponseWriter(w)
-
-			// [!] Pass request on to remote storage server
-			next.ServeHTTP(lrw, r)
-
-			duration := time.Since(start)
-
-			// maybe use an actual library for structured logging
-			log.Printf("%v", map[string]any{
-				"method":   r.Method,
-				"uri":      r.RequestURI,
-				"duration": duration,
-				"status":   lrw.Status,
-				"size":     lrw.Size,
-			})
-		})
-	})
-
-	opts.UseAuthentication(func(r *http.Request, bearer string) (rmsgo.User, bool) {
-		// [!] TODO: Your authentication logic here...
-		//       Return one of your own users.
-		return rmsgo.UserReadWrite{}, true
-	})
 
 	rmsgo.Register(nil)
 	http.ListenAndServe(":8080", nil) // [!] TODO: Use TLS

--- a/storage_test.go
+++ b/storage_test.go
@@ -823,7 +823,7 @@ func TestMigrate(t *testing.T) {
 		rroot = "/storage/"
 		sroot = "/tmp/rms/storage/"
 	)
-	mustVal(Configure(rroot, sroot))
+	must(Configure(rroot, sroot))
 	Mock(
 		WithDirectory(sroot),
 		WithFile("/somewhere/Documents/hello.txt", []byte("Hello, World!")),


### PR DESCRIPTION
Instead of using the builder pattern, switch to using the options pattern which is generally considered more 'idiomatic' in Go.